### PR TITLE
Added another bof exercise.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 WORKDIR /usr/src
 
-RUN apt-get update -y && apt-get install -y build-essential nano vim gdb
+RUN apt-get update -y && apt-get install -y build-essential nano vim gdb gcc-multilib g++-multilib
 
 COPY . .
 

--- a/argcrack/Makefile
+++ b/argcrack/Makefile
@@ -1,0 +1,11 @@
+CC=gcc
+CFLAGS=-g -Wall -fno-stack-protector -m32
+LDFLAGS=
+OBJECTS=main.o
+TARGET=argcrack
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJECTS)
+
+clean:
+	rm -f $(TARGET) *.o

--- a/argcrack/main.c
+++ b/argcrack/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void func(int key) {
+  char overflowme[32];
+  printf("overflow me : ");
+  gets(overflowme); // smash me!
+  if (key == 0x41414141) {
+    printf("Yay..\n");
+  } else {
+    printf("Nay..\n");
+  }
+}
+int main(int argc, char *argv[]) {
+  func(0xdeadbeef);
+  return 0;
+}


### PR DESCRIPTION
Die `gcc-multilib g++-multilib` Installationen werden gebraucht, um das Program auf 32Bit zu kompilieren. 
Das Dockerimage ist dadurch jetzt 642mb groß.